### PR TITLE
feat (update): return contract creator for ezc

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -134,7 +134,14 @@
                     "data-test": "transaction_hash_link"
                   ) %>
                 <% else %>
-                  <p class="alert alert-danger" role="alert"><%= gettext("Error: Could not determine contract creator.") %></p>
+                  <%= if to_string(@address.smart_contract.address_hash) === "0x0000000000000000000000000000000000000000" do %>
+                    <%= link(
+                      trimmed_hash(@address.smart_contract.address_hash),
+                      to: address_path(@conn, :show, @address.smart_contract.address_hash)
+                    ) %>
+                  <% else %>
+                    <p class="alert alert-danger" role="alert"><%= gettext("Error: Could not determine contract creator.") %></p>
+                  <% end %>
                 <% end %>
               </dd>
             </dl>


### PR DESCRIPTION
The feature 'll rename ETH to EZC in smart contract code , and allow return contract creator of 0x00